### PR TITLE
implement call_timeout feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.venv/
 __pycache__/
 *.whl
+/wheels/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: all test clean
 
 all: test
-	pip wheel .
+	pip wheel . --no-deps -w wheels/
 
 test:
 	python -m pytest beef/test
 
 clean:
-	rm -rf *.whl dist
+	rm -rf dist wheels

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: all clean
+.PHONY: all test clean
 
-all:
+all: test
 	pip wheel .
 
+test:
+	python -m pytest beef/test
+
 clean:
-	rm -rf *.whl
+	rm -rf *.whl dist

--- a/README.md
+++ b/README.md
@@ -91,14 +91,26 @@ Finally, run the tests
 python -m pytest beef/test
 ```
 
+or
+
+```bash
+make test
+```
+
 ## Building
 
 ```bash
-pip wheel .
+pip wheel . --no-deps -w wheels/
+```
+
+or
+
+```bash
+make
 ```
 
 ## Publishing
 
 ```bash
-twine upload dist/pybeef-XXX.whl -u __token__ -p <secret-pipy-token>
+twine upload wheels/pybeef-XXX.whl -u __token__ -p <secret-pipy-token>
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ if __name__ == '__main__':
 ```
 
 Client (blocking):
+
 ```python
 async def client():
     async with add.connect('amqp://localhost/'):
@@ -87,7 +88,7 @@ pip install .[test]
 Finally, run the tests
 
 ```bash
-PYTHONPATH=. pytest beef/test
+python -m pytest beef/test
 ```
 
 ## Building

--- a/beef/beef.py
+++ b/beef/beef.py
@@ -281,7 +281,7 @@ class Beef:
                                 import traceback
                                 traceback.print_exc(file=sys.stderr)
                                 status = Status.failure(task_id=task_id, error=repr(e))
-                            except TimeoutError as e:
+                            except asyncio.TimeoutError as e:
                                 status = Status.failure(task_id=task_id, error='Task timed out after %ss' % self._call_timeout_seconds)
                             finally:
                                 self._task_id.set(None)

--- a/beef/beef.py
+++ b/beef/beef.py
@@ -266,7 +266,7 @@ class Beef:
                 # the looping with timeout hack
                 async with self._acquire_channel() as channel:
                     await channel.set_qos(prefetch_count=1)
-                    queue = await channel.declare_queue(self.name, durable=True,)
+                    queue = await channel.declare_queue(self.name, durable=True)
                     async with queue.iterator(no_ack=False, timeout=10) as queue_iter:
                         async for msg in queue_iter:
                             try:

--- a/beef/beef.py
+++ b/beef/beef.py
@@ -145,9 +145,7 @@ class Beef:
         :return: task id
         '''
         async with self._acquire_channel() as channel:
-            await channel.declare_queue(queue_name, durable=True, arguments={
-                'x-consumer-timeout': 30_001,
-            })
+            await channel.declare_queue(queue_name, durable=True)
             task_id = str(uuid.uuid4())
             await channel.declare_queue(task_id, durable=True, arguments={
                 'x-expires': self._reply_expiration_millis,
@@ -268,9 +266,7 @@ class Beef:
                 # the looping with timeout hack
                 async with self._acquire_channel() as channel:
                     await channel.set_qos(prefetch_count=1)
-                    queue = await channel.declare_queue(self.name, durable=True, arguments={
-                        'x-consumer-timeout': 30_002,
-                    })
+                    queue = await channel.declare_queue(self.name, durable=True,)
                     async with queue.iterator(no_ack=False, timeout=10) as queue_iter:
                         async for msg in queue_iter:
                             try:

--- a/beef/test/sample_workers.py
+++ b/beef/test/sample_workers.py
@@ -18,14 +18,6 @@ async def short_lived(*, delay=None, exception=None, ret=None):
         raise exception
     return ret
 
-@beef(call_timeout_seconds=1.0)
-async def timeout_1s(*, delay=None, exception=None, ret=None):
-    if delay is not None:
-        await asyncio.sleep(delay)
-    if exception is not None:
-        raise exception
-    return ret
-
 @beef
 async def universal(*, delay=None, exception=None, ret=None):
     if delay is not None:
@@ -34,12 +26,11 @@ async def universal(*, delay=None, exception=None, ret=None):
         raise exception
     return ret
 
-
 @contextlib.asynccontextmanager
-async def server(beef):
+async def server(beef, *av, **kaw):
     async def server():
         async with beef.connect(url='amqp://localhost/'):
-            await beef.serve()
+            await beef.serve(*av, **kaw)
 
     server_task = asyncio.create_task(server())
 

--- a/beef/test/sample_workers.py
+++ b/beef/test/sample_workers.py
@@ -1,5 +1,6 @@
 from beef import beef
 import asyncio
+import contextlib
 
 @beef
 async def addition(a, b):
@@ -17,6 +18,14 @@ async def short_lived(*, delay=None, exception=None, ret=None):
         raise exception
     return ret
 
+@beef(call_timeout_seconds=1.0)
+async def timeout_1s(*, delay=None, exception=None, ret=None):
+    if delay is not None:
+        await asyncio.sleep(delay)
+    if exception is not None:
+        raise exception
+    return ret
+
 @beef
 async def universal(*, delay=None, exception=None, ret=None):
     if delay is not None:
@@ -24,3 +33,18 @@ async def universal(*, delay=None, exception=None, ret=None):
     if exception is not None:
         raise exception
     return ret
+
+
+@contextlib.asynccontextmanager
+async def server(beef):
+    async def server():
+        async with beef.connect(url='amqp://localhost/'):
+            await beef.serve()
+
+    server_task = asyncio.create_task(server())
+
+    yield
+    server_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await server_task
+

--- a/beef/test/test_beef2.py
+++ b/beef/test/test_beef2.py
@@ -1,0 +1,26 @@
+from beef.test.sample_workers import timeout_1s, server
+import asyncio
+import pytest
+
+@pytest.fixture(scope='function')
+async def timeout_1s_server():
+    async with server(timeout_1s):
+        try:
+            yield
+        finally:
+            await asyncio.sleep(2.0)  # give it chance to finish workers
+
+
+async def test_timeout_1s(timeout_1s_server):
+    async with timeout_1s.connect(url='amqp://localhost/'):
+        task_id = await timeout_1s.submit(delay=0.1, ret=5)
+        result = await timeout_1s.result(task_id=task_id)
+        assert result == 5
+
+
+async def test_timeout_1s_expires(timeout_1s_server):
+    with pytest.raises(Exception, match='task .* failed with remote exception TimeoutError()'):
+        async with timeout_1s.connect(url='amqp://localhost/'):
+            task_id = await timeout_1s.submit(delay=2.0, ret=5)
+            result = await timeout_1s.result(task_id=task_id)
+            assert result == 5

--- a/beef/test/test_beef2.py
+++ b/beef/test/test_beef2.py
@@ -1,26 +1,76 @@
-from beef.test.sample_workers import timeout_1s, server
+from beef.test.sample_workers import universal, server
 import asyncio
 import pytest
+import contextlib
+import sys
 
-@pytest.fixture(scope='function')
-async def timeout_1s_server():
-    async with server(timeout_1s):
+async def universal_server(*av, **kaw):
+    async with server(universal, *av, **kaw):
         try:
             yield
         finally:
             await asyncio.sleep(2.0)  # give it chance to finish workers
 
-
-async def test_timeout_1s(timeout_1s_server):
-    async with timeout_1s.connect(url='amqp://localhost/'):
-        task_id = await timeout_1s.submit(delay=0.1, ret=5)
-        result = await timeout_1s.result(task_id=task_id)
-        assert result == 5
-
-
-async def test_timeout_1s_expires(timeout_1s_server):
-    with pytest.raises(Exception, match='task .* failed with remote exception TimeoutError()'):
-        async with timeout_1s.connect(url='amqp://localhost/'):
-            task_id = await timeout_1s.submit(delay=2.0, ret=5)
-            result = await timeout_1s.result(task_id=task_id)
+async def test_timeout_1s():
+    async with server(universal, task_timeout_seconds=1.0):
+        async with universal.connect(url='amqp://localhost/'):
+            task_id = await universal.submit(delay=0.1, ret=5)
+            result = await universal.result(task_id=task_id)
             assert result == 5
+
+
+async def test_timeout_1s_expires():
+    async with server(universal, task_timeout_seconds=1.0):
+        with pytest.raises(Exception, match='task .* failed with remote exception Task timed out after 1.0s'):
+            async with universal.connect(url='amqp://localhost/'):
+                task_id = await universal.submit(delay=2.0, ret=5)
+                result = await universal.result(task_id=task_id)
+                assert result == 5
+
+        # call server again to make sure it did not exit on timeout!
+        async with universal.connect(url='amqp://localhost/'):
+            task_id = await universal.submit(delay=0.1, ret=55)
+            result = await universal.result(task_id=task_id)
+            assert result == 55
+
+
+async def test_timeout_1s_expires_and_exits():
+
+    async def server(beef, *av, **kaw):
+        async with beef.connect(url='amqp://localhost/'):
+            await beef.serve(*av, **kaw)
+
+    server_task = asyncio.create_task(server(universal, task_timeout_seconds=1.0, exit_on_task_timeout=True))
+    try:
+        with pytest.raises(Exception, match='task .* failed with remote exception Task timed out after 1.0s'):
+            async with universal.connect(url='amqp://localhost/'):
+                task_id = await universal.submit(delay=2.0, ret=5)
+                await universal.result(task_id=task_id)
+
+        await asyncio.sleep(1.0)
+        assert server_task.done()
+    finally:
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
+
+
+async def test_timeout_1s_expires_and_does_not_exit():
+
+    async def server(beef, *av, **kaw):
+        async with beef.connect(url='amqp://localhost/'):
+            await beef.serve(*av, **kaw)
+
+    server_task = asyncio.create_task(server(universal, task_timeout_seconds=1.0))
+    try:
+        with pytest.raises(Exception, match='task .* failed with remote exception Task timed out after 1.0s'):
+            async with universal.connect(url='amqp://localhost/'):
+                task_id = await universal.submit(delay=2.0, ret=5)
+                await universal.result(task_id=task_id)
+
+        await asyncio.sleep(1.0)
+        assert not server_task.done()
+    finally:
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pybeef"
-version = "0.0.12"
+version = "0.0.13"
 authors = [
     { name="Mike Kroutikov", email="mkroutikov@innodata.com" },
 ]
@@ -26,9 +26,12 @@ test = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/innodatalabs/beef"
-"Bug Tracker" = "https://github.com/pypa/innodatalabs/beef"
+"Homepage" = "https://github.com/innodatalabs/pybeef"
+"Bug Tracker" = "https://github.com/pypa/innodatalabs/pybeef"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+    packages = ["beef"]


### PR DESCRIPTION
Beef server can now be configured with `call_timeout_seconds` parameter. If RPC function does not return within given time frame, call fails.